### PR TITLE
fix an error in use torch

### DIFF
--- a/torch.js
+++ b/torch.js
@@ -109,10 +109,10 @@ class Torch {
 		 */
 		async function useTorch() {
 			let torch = -1;
-
-			if (data.isGM && !game.settings.get("torch", "gmUsesInventory"))
-				return;
+			
 			if (game.system.id !== 'dnd5e')
+				return;
+			if (data.isGM && !game.settings.get("torch", "gmUsesInventory"))
 				return;
 			let actor = game.actors.get(data.actorId);
 			if (actor === undefined)


### PR DESCRIPTION
You should return if the system is not 'dnd5e' before validating other params this provoke an error in other system. Nice module ;)